### PR TITLE
Added fortios_vpn_certificate_local_info module.

### DIFF
--- a/plugins/modules/fortios_vpn_certificate_local_info.py
+++ b/plugins/modules/fortios_vpn_certificate_local_info.py
@@ -1,0 +1,303 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_vpn_certificate_local_info
+short_description: Get info about local keys and certificates in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to retrieve infomation about a FortiGate or FortiOS (FOS) device's
+      vpn_certificate local certificate store.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.9
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+    - Judd Tracy (@JuddTracy-DAS)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    vpn_certificate_local:
+        description:
+            - Local keys and certificates.
+        default: "{ "name": "*" }"
+        type: dict
+        suboptions:
+            name:
+                description:
+                    - Name.
+                required: true
+                type: str
+                default: "*"
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Local keys and certificates.
+    fortios_vpn_certificate_local:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      vpn_certificate_local:
+        name: "*"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+results:
+  description: List of certificates found on the device
+  returned: always
+  type: list
+  sample: "results:
+      - auto-regenerate-days: 0
+        auto-regenerate-days-warning: 0
+        ca-identifier: ''
+        certificate: ''
+        cmp-regeneration-method: keyupate
+        comments: Example.com Certificate
+        csr: ''
+        enroll-protocol: none
+        ike-localid: ''
+        ike-localid-type: asn1dn
+        last-updated: 1589223709
+        name: example.com
+        name-encoding: printable
+        password: ENC XXXX
+        private-key: ''
+        q_origin_key: example.com
+        range: global
+        scep-password: ''
+        source: user
+        source-ip: 0.0.0.0
+        state: ''"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_vpn_certificate_local_info_data(json):
+    option_list = ['name']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def vpn_certificate_local_info(data, fos):
+    vdom = data['vdom']
+    name = data['vpn_certificate_local']['name']
+
+    if name == "*":
+        return fos.get('vpn.certificate', 'local', vdom=vdom)
+    
+    else:
+        return fos.get('vpn.certificate', 'local', mkey=name, vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success"
+
+
+def fortios_vpn_certificate_info(data, fos):
+    if data['vpn_certificate_local']:
+        resp = vpn_certificate_local_info(data, fos)
+
+    return not is_successful_status(resp), \
+        False, \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "vpn_certificate_local": {
+            "required": False, "type": "dict", "default": {"name": "*"},
+            "options": {
+                "name": {"required": False, "type": "str", "default": "*"},
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_vpn_certificate_info(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_vpn_certificate_info(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I created a module that retrieves information about the certificates stored in the local vpn certificate store.  It was based of the fortios_vpn_certificate_local with everything not related to retrieving the certificates removed.  I have tested it locally on my v6.0.9 device but I don't have any other devices to test with.  But the module is relatively simple and should be easy to review.