### PR TITLE
SyntaxError: invalid syntax

### DIFF
--- a/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_advice_of_charge.py
+++ b/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_advice_of_charge.py
@@ -278,8 +278,7 @@ def wireless_controller_hotspot20_h2qp_advice_of_charge(data, fos):
     state = data['state']
 
     wireless_controller_hotspot20_h2qp_advice_of_charge_data = data['wireless_controller_hotspot20_h2qp_advice_of_charge']
-    filtered_data =
-    underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_advice_of_charge_data(wireless_controller_hotspot20_h2qp_advice_of_charge_data))
+    filtered_data = underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_advice_of_charge_data(wireless_controller_hotspot20_h2qp_advice_of_charge_data))
 
     if state == "present" or state is True:
         return fos.set('wireless-controller.hotspot20',

--- a/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_osu_provider_nai.py
+++ b/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_osu_provider_nai.py
@@ -235,8 +235,7 @@ def wireless_controller_hotspot20_h2qp_osu_provider_nai(data, fos):
     state = data['state']
 
     wireless_controller_hotspot20_h2qp_osu_provider_nai_data = data['wireless_controller_hotspot20_h2qp_osu_provider_nai']
-    filtered_data =
-    underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_osu_provider_nai_data(wireless_controller_hotspot20_h2qp_osu_provider_nai_data))
+    filtered_data = underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_osu_provider_nai_data(wireless_controller_hotspot20_h2qp_osu_provider_nai_data))
 
     if state == "present" or state is True:
         return fos.set('wireless-controller.hotspot20',

--- a/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_terms_and_conditions.py
+++ b/plugins/modules/fortios_wireless_controller_hotspot20_h2qp_terms_and_conditions.py
@@ -233,8 +233,7 @@ def wireless_controller_hotspot20_h2qp_terms_and_conditions(data, fos):
     state = data['state']
 
     wireless_controller_hotspot20_h2qp_terms_and_conditions_data = data['wireless_controller_hotspot20_h2qp_terms_and_conditions']
-    filtered_data =
-    underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_terms_and_conditions_data(wireless_controller_hotspot20_h2qp_terms_and_conditions_data))
+    filtered_data = underscore_to_hyphen(filter_wireless_controller_hotspot20_h2qp_terms_and_conditions_data(wireless_controller_hotspot20_h2qp_terms_and_conditions_data))
 
     if state == "present" or state is True:
         return fos.set('wireless-controller.hotspot20',


### PR DESCRIPTION
When packing Ansible 5.7.0 as .deb/.rpm (see https://github.com/alvistack/ansible-community-ansible-build-data/commit/f3cb88964b44be336e8d543309c80b4d7d442d50), apt generate following error message when install the result package:
```
Setting up ansible (100:5.7.0-1) ...
  File "/usr/lib/python3/dist-packages/ansible_collections/fortinet/fortios/plugins/modules/fortios_wirel
ess_controller_hotspot20_h2qp_advice_of_charge.py", line 281
    filtered_data =
                  ^
SyntaxError: invalid syntax

  File "/usr/lib/python3/dist-packages/ansible_collections/fortinet/fortios/plugins/modules/fortios_wirel
ess_controller_hotspot20_h2qp_osu_provider_nai.py", line 238
    filtered_data =
                  ^
SyntaxError: invalid syntax

  File "/usr/lib/python3/dist-packages/ansible_collections/fortinet/fortios/plugins/modules/fortios_wirel
ess_controller_hotspot20_h2qp_terms_and_conditions.py", line 236
    filtered_data =
                  ^
SyntaxError: invalid syntax

dpkg: error processing package ansible (--configure):
 installed ansible package post-installation script subprocess returned error exit status 1
```

Fixes https://github.com/ansible-community/ansible-build-data/issues/114