### PR TITLE
Update fortios_switch_controller_dynamic_port_policy.py

### DIFF
--- a/plugins/modules/fortios_switch_controller_dynamic_port_policy.py
+++ b/plugins/modules/fortios_switch_controller_dynamic_port_policy.py
@@ -325,7 +325,7 @@ def underscore_to_hyphen(data):
 
 
 def valid_attr_to_invalid_attr(data):
-    specillist = {"802_1x": "set_802_1x"}
+    specillist = {"802-1x": "set-802-1x"}
 
     for k, v in specillist.items():
         if v == data:
@@ -336,8 +336,11 @@ def valid_attr_to_invalid_attr(data):
 
 def valid_attr_to_invalid_attrs(data):
     if isinstance(data, list):
+        new_data = []
         for elem in data:
             elem = valid_attr_to_invalid_attrs(elem)
+            new_data.append(elem)
+        data = new_data
     elif isinstance(data, dict):
         new_data = {}
         for k, v in data.items():


### PR DESCRIPTION
BugFix. 802-1x not updating. The renaming of the key didn't work for 2 reasons:
- the underscore to hyphen function had already renamed the key with hyphen
- when the value of the object is a list, the renamed elements of the list were not saved