### PR TITLE
Correcting DLP Profile "type" property

### DIFF
--- a/plugins/modules/fortios_dlp_profile.py
+++ b/plugins/modules/fortios_dlp_profile.py
@@ -260,7 +260,7 @@ options:
                         type: str
                         choices:
                             - 'file'
-                            - 'fos_message'
+                            - 'message'
             summary_proto:
                 description:
                     - Protocols to always log summary.
@@ -466,7 +466,7 @@ def underscore_to_hyphen(data):
 
 
 def valid_attr_to_invalid_attr(data):
-    speciallist = {"message": "fos_message"}
+    speciallist = {"message": "message"}
 
     for k, v in speciallist.items():
         if v == data:
@@ -574,7 +574,7 @@ versioned_schema = {
                 "type": {
                     "v_range": [["v7.2.0", ""]],
                     "type": "string",
-                    "options": [{"value": "file"}, {"value": "fos_message"}],
+                    "options": [{"value": "file"}, {"value": "message"}],
                 },
                 "proto": {
                     "v_range": [["v7.2.0", ""]],


### PR DESCRIPTION
Correcting DLP Profile "type" property

See notes in issue:
https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/312

This has been tested in my dev environment and proven to work.

fortios_dlp_profile -> dlp_profile rule property "Type" will properly create and update when value is "message". This removes a bug where property "fos_message" was expected, but not working as intended. Instead fos_message value was implicitly ignoring the assertion which used the default value of "file" in FortiOS config.