### PR TITLE
Fixed reference to seq-num key in removing route

### DIFF
--- a/plugins/modules/fortios_router_static.py
+++ b/plugins/modules/fortios_router_static.py
@@ -459,7 +459,7 @@ def router_static(data, fos, check_mode=False):
         return fos.set("router", "static", data=converted_data, vdom=vdom)
 
     elif state == "absent":
-        return fos.delete("router", "static", mkey=filtered_data["seq-num"], vdom=vdom)
+        return fos.delete("router", "static", mkey=filtered_data["seq_num"], vdom=vdom)
     else:
         fos._module.fail_json(msg="state must be present or absent!")
 


### PR DESCRIPTION
Code:

```yaml
- name: Unwanted routes
  set_fact:
    routes_to_remove: ['12']

- name: Remove unwanted management routes
  fortinet.fortios.fortios_router_static:
    state: "absent"
    router_static:
      seq_num: "{{ item | int }}"
  with_items: "{{ routes_to_remove }}"
```

Gives the following error:

```yaml
failed: [vm-vpn-prod-0001a] (item=12) => {"ansible_loop_var": "item", "changed": false, "item": 12, "module_stderr": "Traceback (most recent call last):
  File \"/home/app/.ansible/tmp/ansible-local-139a965oo/ansible-tmp-1718358053.3592625-747-259437597361998/AnsiballZ_fortios_router_static.py\", line 107, in <module>
    _ansiballz_main()
  File \"/home/app/.ansible/tmp/ansible-local-139a965oo/ansible-tmp-1718358053.3592625-747-259437597361998/AnsiballZ_fortios_router_static.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/home/app/.ansible/tmp/ansible-local-139a965oo/ansible-tmp-1718358053.3592625-747-259437597361998/AnsiballZ_fortios_router_static.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.fortinet.fortios.plugins.modules.fortios_router_static', init_globals=dict(_module_fqn='ansible_collections.fortinet.fortios.plugins.modules.fortios_router_static', _modlib_path=modlib_path),
  File \"<frozen runpy>\", line 226, in run_module
  File \"<frozen runpy>\", line 98, in _run_module_code
  File \"<frozen runpy>\", line 88, in _run_code
  File \"/tmp/ansible_fortinet.fortios.fortios_router_static_payload__1uppy45/ansible_fortinet.fortios.fortios_router_static_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_router_static.py\", line 652, in <module>
  File \"/tmp/ansible_fortinet.fortios.fortios_router_static_payload__1uppy45/ansible_fortinet.fortios.fortios_router_static_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_router_static.py\", line 618, in main
  File \"/tmp/ansible_fortinet.fortios.fortios_router_static_payload__1uppy45/ansible_fortinet.fortios.fortios_router_static_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_router_static.py\", line 482, in fortios_router
  File \"/tmp/ansible_fortinet.fortios.fortios_router_static_payload__1uppy45/ansible_fortinet.fortios.fortios_router_static_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_router_static.py\", line 462, in router_static
KeyError: 'seq-num'
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```

This seems to be because in [fortios_router_static.py:462](https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/blob/main/plugins/modules/fortios_router_static.py#L462) there is a reference to `seq-num` in a dictionary where all hyphens are converted to underscores (so it should be `seq_num`).

After changing the hyphen to underscore in the code; it can remove routes:

```yaml
TASK [network : Remove unwanted management routes state=absent, router_static={'seq_num': '{{ item | int }}'}] ***************************
changed: [vm-vpn-prod-0001b] => (item=12)
changed: [vm-vpn-prod-0001a] => (item=12)

PLAY RECAP *******************************************************************************************************************************
vm-vpn-prod-0001a          : ok=40   changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
vm-vpn-prod-0001b          : ok=40   changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0  
```
