### PR TITLE
feat(playbook): auto-block malicious IPs from threat feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,3 +796,5 @@ The collection incluses the following modules:
 ## License Information
 
 FortiOS Ansible Collection follows [GNU General Public License v3.0](./LICENSE).
+### Automation Playbooks
+- `playbooks/auto-block-malicious-ips.yml` – Auto-blocks live malicious IPs from threat feed

--- a/examples/auto-block-malicious-ips.yml
+++ b/examples/auto-block-malicious-ips.yml
@@ -7,7 +7,7 @@
   hosts: fortigate
   gather_facts: no
   vars:
-    threat_feed: "https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt"
+    threat_feed: "https://rules.emergingthreats.net/blockrules/compromised-ips.txt"
   tasks:
     - name: Fetch latest malicious IPs
       uri:

--- a/examples/auto-block-malicious-ips.yml
+++ b/examples/auto-block-malicious-ips.yml
@@ -1,0 +1,23 @@
+---
+# Auto-block malicious IPs on FortiGate
+# Enterprise Security Lab | Manjula Wickramasuriya
+# Network Defense Automation
+# Note: Pairs with FortiOS external threat feeds for .txt import (no playbook needed for basic use).
+- name: Block known bad IPs
+  hosts: fortigate
+  gather_facts: no
+  vars:
+    threat_feed: "https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt"
+  tasks:
+    - name: Fetch latest malicious IPs
+      uri:
+        url: "{{ threat_feed }}"
+        return_content: yes
+      register: bad_ips
+      delegate_to: localhost
+
+    - name: Block each IP (demo output)
+      debug:
+        msg: "BLOCKED {{ item }} on FortiGate (would use fortios_ipmask)"
+      loop: "{{ bad_ips.content.splitlines() | select('match', '^[0-9]') | list[:5] }}"
+      when: bad_ips.content is defined

--- a/examples/auto-import-threat-feed.yml
+++ b/examples/auto-import-threat-feed.yml
@@ -1,0 +1,65 @@
+---
+# FortiOS External Threat Feed Integration
+# Auto-imports and blocks malicious IPs from public feeds
+# Demo-safe – works on any FortiGate
+- name: Import external threat feed
+  hosts: fortigate
+  gather_facts: no
+  collections:
+    - fortinet.fortios
+
+  vars:
+    vdom: "root"
+    threat_feeds:
+      - name: "Abuse-CH-Feodo"
+        url: "https://feodotracker.abuse.ch/downloads/ipblocklist.txt"
+        comment: "Feodo Tracker C&C IPs"
+      - name: "Emer0.0gingThreats-Compromised"
+        url: "https://rules.emergingthreats.net/blockrules/compromised-ips.txt"
+        comment: "Emerging Threats compromised IPs"
+
+  tasks:
+    - name: Configure external threat feed addresses
+      fortinet.fortios.fortios_firewall_address:
+        vdom: "{{ vdom }}"
+        state: "present"
+        firewall_address:
+          name: "{{ item.name }}"
+          type: "threat-feed"
+          threat_feed_url: "{{ item.url }}"
+          comment: "{{ item.comment }}"
+          visibility: "enable"
+          allow_routing: "disable"
+      loop: "{{ threat_feeds }}"
+      register: threat_feed_result
+
+    - name: Create address group for all threat feeds
+      fortinet.fortios.fortios_firewall_addrgrp:
+        vdom: "{{ vdom }}"
+        state: "present"
+        firewall_addrgrp:
+          name: "External-Threat-Feeds"
+          comment: "Consolidated external threat intelligence"
+          member: "{{ threat_feeds | map(attribute='name') | list }}"
+          visibility: "enable"
+
+    - name: Create firewall policy to block threat feed IPs
+      fortinet.fortios.fortios_firewall_policy:
+        vdom: "{{ vdom }}"
+        state: "present"
+        firewall_policy:
+          policyid: 100
+          name: "Block-External-Threats"
+          srcintf: [{"name": "any"}]
+          dstintf: [{"name": "any"}]
+          srcaddr: [{ "name": "External-Threat-Feeds" }]
+          dstaddr: [{ "name": "all" }]
+          action: "deny"
+          schedule: "always"
+          service: [{ "name": "ALL" }]
+          logtraffic: "all"
+          comments: "Block traffic from known malicious IPs"
+
+    - name: Display configuration status
+      debug:
+        msg: "Successfully configured {{ threat_feeds | length }} threat feed(s)"

--- a/examples/auto-import-threat-feed.yml
+++ b/examples/auto-import-threat-feed.yml
@@ -62,4 +62,4 @@
 
     - name: Display configuration status
       debug:
-        msg: "Successfully configured {{ threat_feeds | length }} threat feed(s)"
+        msg: "Successfully configured {{ threat_feeds | length }} threat feed(s)" 

--- a/playbooks/auto-block-malicious-ips.yml
+++ b/playbooks/auto-block-malicious-ips.yml
@@ -1,0 +1,22 @@
+---
+# Auto-block malicious IPs on FortiGate
+# Enterprise Security Lab | Manjula Wickramasuriya
+# Network Defense Automation
+- name: Block known bad IPs
+  hosts: fortigate
+  gather_facts: no
+  vars:
+    threat_feed: "https://rules.emergingthreats.net/blockrules/emerging-Block-IPs.txt"
+  tasks:
+    - name: Fetch latest malicious IPs
+      uri:
+        url: "{{ threat_feed }}"
+        return_content: yes
+      register: bad_ips
+      delegate_to: localhost
+
+    - name: Block each IP (demo output)
+      debug:
+        msg: "BLOCKED {{ item }} on FortiGate (would use fortios_ipmask)"
+      loop: "{{ bad_ips.content.splitlines() | select('match', '^[0-9]') | list[:5] }}"
+      when: bad_ips.content is defined

--- a/playbooks/auto-block-malicious-ips.yml
+++ b/playbooks/auto-block-malicious-ips.yml
@@ -6,7 +6,7 @@
   hosts: fortigate
   gather_facts: no
   vars:
-    threat_feed: "https://rules.emergingthreats.net/blockrules/emerging-Block-IPs.txt"
+    threat_feed: "https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt"
   tasks:
     - name: Fetch latest malicious IPs
       uri:

--- a/playbooks/auto-block-malicious-ips.yml
+++ b/playbooks/auto-block-malicious-ips.yml
@@ -2,6 +2,7 @@
 # Auto-block malicious IPs on FortiGate
 # Enterprise Security Lab | Manjula Wickramasuriya
 # Network Defense Automation
+# Note: Pairs with FortiOS external threat feeds for .txt import (no playbook needed for basic use).
 - name: Block known bad IPs
   hosts: fortigate
   gather_facts: no


### PR DESCRIPTION
Automatically blocks known malicious IPs on FortiGate using a public threat feed.

- Fetches live data from Emerging Threats (updated URL: 'compromised-ips.txt')
- Demo mode (no device or credentials needed)
- Pairs with FortiOS external threat feeds for .txt import
- Moved to `examples/` for better fit in collection

See 'playbooks/auto-block-malicious-ips.yml'